### PR TITLE
Always update

### DIFF
--- a/src/core/engine/Converter.ts
+++ b/src/core/engine/Converter.ts
@@ -1,6 +1,6 @@
 import { CONNECTION_TYPE } from "../connections/EngineConnections";
 import { LogicIO } from "../IO/LogicIO";
-import { ConfigNodeDict } from "../nodes/ConfigNode";
+import { ConfigNodeDict, updateType } from "../nodes/ConfigNode";
 import { EngineNodeDict } from "../nodes/EngineNode";
 import { LogicNode, LogicNodeDict } from "../nodes/LogicNode";
 import { GraphExe } from "./Core";
@@ -49,12 +49,12 @@ export const nodeConverter = (graph: GraphExe, config: ConfigNodeDict, nodeDict:
         })
 
         const trigger = config[value.configId].isTrigger;
-        const update = config[value.configId].alwaysUpdate;
+        const update = config[value.configId].updateType;
 
         const logicNode: LogicNode = {
             id: value.id,
             isTrigger: !(trigger === undefined) ? trigger : false,
-            alwaysUpdate: !(update === undefined) ? update : false,
+            updateType: !(update === undefined) ? update : updateType.NEVER,
             computed: false,
             inputs: graphIoInput,
             outputs: graphIoOutput,

--- a/src/core/engine/Converter.ts
+++ b/src/core/engine/Converter.ts
@@ -49,10 +49,13 @@ export const nodeConverter = (graph: GraphExe, config: ConfigNodeDict, nodeDict:
         })
 
         const trigger = config[value.configId].isTrigger;
+        const update = config[value.configId].alwaysUpdate;
 
         const logicNode: LogicNode = {
             id: value.id,
             isTrigger: !(trigger === undefined) ? trigger : false,
+            alwaysUpdate: !(update === undefined) ? update : false,
+            computed: false,
             inputs: graphIoInput,
             outputs: graphIoOutput,
             exe: config[value.configId].exe,

--- a/src/core/engine/Core.ts
+++ b/src/core/engine/Core.ts
@@ -3,6 +3,7 @@ import { ConnectionDetails, CONNECTION_TYPE, EngineConnections, IoIdInfo } from 
 import { extractor, NodePorts } from "../connections/Extractor";
 import { EngineIO } from "../IO/EngineIO";
 import { LogicIO } from "../IO/LogicIO";
+import { updateType } from "../nodes/ConfigNode";
 import { LogicNode, LogicNodeDict } from "../nodes/LogicNode";
 
 /**
@@ -64,8 +65,20 @@ const resolveDependency = (node: LogicNode, graph: GraphExe) => {
         dependencies.forEach(dep => {
 
             //execute the dependencyNode and set it's ioPorts value
-            if (!graph.nodes[dep.nodeId].computed || graph.nodes[dep.nodeId].alwaysUpdate)
-                executeNode(graph.nodes[dep.nodeId], false, graph);
+            switch (graph.nodes[dep.nodeId].updateType) {
+                case updateType.NEVER:
+                    if (!graph.nodes[dep.nodeId].computed)
+                        executeNode(graph.nodes[dep.nodeId], false, graph);
+                    break;
+                case updateType.DYNAMIC:
+                    if (!graph.nodes[dep.nodeId].computed ||
+                        needsUpdate(graph.nodes[dep.nodeId], graph))
+                        executeNode(graph.nodes[dep.nodeId], false, graph);
+                    break;
+                case updateType.ALWAYS:
+                    executeNode(graph.nodes[dep.nodeId], false, graph);
+                    break;
+            }
 
             //assign the computed value to this input now
             node.inputs[con.index].value = graph.nodes[dep.nodeId].outputs[dep.index].value;
@@ -256,6 +269,34 @@ const traverseNodeInput = (nodeInfo: NodeIoInfo, connections: EngineConnections,
     }
 
     return foundLoop;
+}
+
+/**
+ * Return true if the input parameters for this node are different to it's set values, indicating that a change happened 
+ * @param node The node to check if their parameters are still up to date
+ * @param graph The graph this node is in
+ * @returns 
+ */
+const needsUpdate = (node: LogicNode, graph: GraphExe): boolean => {
+
+    const ports: NodePorts = extractor(node);
+
+    let needsUpdate: boolean = false;
+
+    for (let i = 0; i < ports.inputs.length; i++) {
+
+        const dependencies: ConnectionDetails[] = connectionFinder(ports.inputs[i], graph.connections);
+
+        if (dependencies.length == 0)
+            continue;
+
+        if (node.inputs[i].value !== graph.nodes[dependencies[0].nodeId].outputs[dependencies[0].index].value) {
+            needsUpdate = true;
+            break;
+        }
+    }
+
+    return needsUpdate;
 }
 
 /**

--- a/src/core/engine/Core.ts
+++ b/src/core/engine/Core.ts
@@ -39,6 +39,7 @@ export const executeNode = (node: LogicNode, isTriggered: boolean, graph: GraphE
     resolveDependency(node, graph);
     if (graph.calleeDict[node.id] && !isTriggered) return;
     node.exe(...node.inputs, ...node.outputs);
+    node.computed = true;
 }
 
 /**
@@ -63,7 +64,8 @@ const resolveDependency = (node: LogicNode, graph: GraphExe) => {
         dependencies.forEach(dep => {
 
             //execute the dependencyNode and set it's ioPorts value
-            executeNode(graph.nodes[dep.nodeId], false, graph);
+            if (!graph.nodes[dep.nodeId].computed || graph.nodes[dep.nodeId].alwaysUpdate)
+                executeNode(graph.nodes[dep.nodeId], false, graph);
 
             //assign the computed value to this input now
             node.inputs[con.index].value = graph.nodes[dep.nodeId].outputs[dep.index].value;

--- a/src/core/nodes/ConfigNode.ts
+++ b/src/core/nodes/ConfigNode.ts
@@ -4,6 +4,7 @@ import { EngineIO } from "../IO/EngineIO";
  * ConfigNode defines the functionality of the node.
  * id: Unique config id
  * isTrigger: If true, node will call next() action even if called as a dependency. Default: false
+ * alwaysUpdate: If true will always recalculate this node when requested as a dependency. Default: false
  * inputs: Ingoing connections of this node
  * outputs: Outgoing connections of this node
  * exe: function to execute when this node get triggered
@@ -13,6 +14,7 @@ import { EngineIO } from "../IO/EngineIO";
 export interface ConfigNode {
     id: string;
     isTrigger?: boolean;
+    alwaysUpdate?: boolean;
     inputs: EngineIO<any, any>[],
     outputs: EngineIO<any, any>[],
     exe: (...io: EngineIO<any, any>[]) => void;

--- a/src/core/nodes/ConfigNode.ts
+++ b/src/core/nodes/ConfigNode.ts
@@ -1,10 +1,19 @@
 import { EngineIO } from "../IO/EngineIO";
 
+export enum updateType {
+    NEVER,
+    DYNAMIC,
+    ALWAYS
+}
+
 /**
  * ConfigNode defines the functionality of the node.
  * id: Unique config id
  * isTrigger: If true, node will call next() action even if called as a dependency. Default: false
- * alwaysUpdate: If true will always recalculate this node when requested as a dependency. Default: false
+ * updateType: Determines how a dependency request should be handled. Default: NEVER
+ *  NEVER: Only computes the node once when requested as a dependency
+ *  DYNAMIC: Only computes the node when it's connected input values have been changed
+ *  ALWAYS: Always recomputes the node upon dependency request
  * inputs: Ingoing connections of this node
  * outputs: Outgoing connections of this node
  * exe: function to execute when this node get triggered
@@ -14,7 +23,7 @@ import { EngineIO } from "../IO/EngineIO";
 export interface ConfigNode {
     id: string;
     isTrigger?: boolean;
-    alwaysUpdate?: boolean;
+    updateType?: updateType;
     inputs: EngineIO<any, any>[],
     outputs: EngineIO<any, any>[],
     exe: (...io: EngineIO<any, any>[]) => void;

--- a/src/core/nodes/EngineNode.ts
+++ b/src/core/nodes/EngineNode.ts
@@ -11,7 +11,7 @@ import { EngineIO } from "../IO/EngineIO";
 export interface EngineNode {
     id: string;
     configId: string;
-    autoUpdate: boolean;
+    alwaysUpdate: boolean;
     inputs: EngineIO<any, any>[];
     outputs: EngineIO<any, any>[];
 }

--- a/src/core/nodes/LogicNode.ts
+++ b/src/core/nodes/LogicNode.ts
@@ -6,6 +6,8 @@ import { LogicIO } from "../IO/LogicIO";
 export interface LogicNode {
     id: string;
     isTrigger: boolean;
+    alwaysUpdate: boolean;
+    computed: boolean;
     inputs: LogicIO<any, any>[];
     outputs: LogicIO<any, any>[];
     exe: (...io: LogicIO<any, any>[]) => void;

--- a/src/core/nodes/LogicNode.ts
+++ b/src/core/nodes/LogicNode.ts
@@ -1,4 +1,5 @@
 import { LogicIO } from "../IO/LogicIO";
+import { updateType } from "./ConfigNode";
 
 /**
  * Similar to EngineNode, but store a OTG_IO instead of a Engine Node to work while executing the graph
@@ -6,7 +7,7 @@ import { LogicIO } from "../IO/LogicIO";
 export interface LogicNode {
     id: string;
     isTrigger: boolean;
-    alwaysUpdate: boolean;
+    updateType: updateType;
     computed: boolean;
     inputs: LogicIO<any, any>[];
     outputs: LogicIO<any, any>[];

--- a/tests/core/predefined/ConfigNodes.ts
+++ b/tests/core/predefined/ConfigNodes.ts
@@ -91,6 +91,7 @@ export const ifNode: ConfigNode = {
 
 export const numberToStringConverterNode: ConfigNode = {
     id: "numberToStringConverterNode",
+    alwaysUpdate: true,
     inputs: [numberIn],
     outputs: [stringOut],
     exe: function (numberIn: EngineIO<null, number>, stringOut: EngineIO<null, string>) {
@@ -144,6 +145,7 @@ export const subNode: ConfigNode = {
 
 export const mulNode: ConfigNode = {
     id: "mulNode",
+    alwaysUpdate: true,
     inputs: [numberIn, numberIn],
     outputs: [numberOut],
     exe: function (in1: EngineIO<null, number>, in2: EngineIO<null, number>, out: EngineIO<null, number>): void {

--- a/tests/core/predefined/ConfigNodes.ts
+++ b/tests/core/predefined/ConfigNodes.ts
@@ -1,6 +1,6 @@
 import { next } from "../../../src/core/engine/Core";
 import { EngineIO } from "../../../src/core/IO/EngineIO";
-import { ConfigNode, ConfigNodeDict } from "../../../src/core/nodes/ConfigNode";
+import { ConfigNode, ConfigNodeDict, updateType } from "../../../src/core/nodes/ConfigNode";
 import { numberIn, signalIn, stringIn } from "./InputPorts";
 import { numberOut, signalOut, stringOut } from "./OutputPorts";
 
@@ -91,7 +91,7 @@ export const ifNode: ConfigNode = {
 
 export const numberToStringConverterNode: ConfigNode = {
     id: "numberToStringConverterNode",
-    alwaysUpdate: true,
+    updateType: updateType.ALWAYS,
     inputs: [numberIn],
     outputs: [stringOut],
     exe: function (numberIn: EngineIO<null, number>, stringOut: EngineIO<null, string>) {
@@ -127,7 +127,7 @@ export const constNode: ConfigNode = {
 
 export const addNode: ConfigNode = {
     id: "addNode",
-    alwaysUpdate: true,
+    updateType: updateType.DYNAMIC,
     inputs: [numberIn, numberIn],
     outputs: [numberOut],
     exe: function (in1: EngineIO<null, number>, in2: EngineIO<null, number>, out: EngineIO<null, number>): void {
@@ -137,7 +137,7 @@ export const addNode: ConfigNode = {
 
 export const subNode: ConfigNode = {
     id: "subNode",
-    alwaysUpdate: true,
+    updateType: updateType.DYNAMIC,
     inputs: [numberIn, numberIn],
     outputs: [numberOut],
     exe: function (in1: EngineIO<null, number>, in2: EngineIO<null, number>, out: EngineIO<null, number>): void {
@@ -147,7 +147,7 @@ export const subNode: ConfigNode = {
 
 export const mulNode: ConfigNode = {
     id: "mulNode",
-    alwaysUpdate: true,
+    updateType: updateType.DYNAMIC,
     inputs: [numberIn, numberIn],
     outputs: [numberOut],
     exe: function (in1: EngineIO<null, number>, in2: EngineIO<null, number>, out: EngineIO<null, number>): void {
@@ -157,7 +157,7 @@ export const mulNode: ConfigNode = {
 
 export const divNode: ConfigNode = {
     id: "divNode",
-    alwaysUpdate: true,
+    updateType: updateType.DYNAMIC,
     inputs: [numberIn, numberIn],
     outputs: [numberOut],
     exe: function (in1: EngineIO<null, number>, in2: EngineIO<null, number>, out: EngineIO<null, number>): void {

--- a/tests/core/predefined/ConfigNodes.ts
+++ b/tests/core/predefined/ConfigNodes.ts
@@ -127,6 +127,7 @@ export const constNode: ConfigNode = {
 
 export const addNode: ConfigNode = {
     id: "addNode",
+    alwaysUpdate: true,
     inputs: [numberIn, numberIn],
     outputs: [numberOut],
     exe: function (in1: EngineIO<null, number>, in2: EngineIO<null, number>, out: EngineIO<null, number>): void {
@@ -136,6 +137,7 @@ export const addNode: ConfigNode = {
 
 export const subNode: ConfigNode = {
     id: "subNode",
+    alwaysUpdate: true,
     inputs: [numberIn, numberIn],
     outputs: [numberOut],
     exe: function (in1: EngineIO<null, number>, in2: EngineIO<null, number>, out: EngineIO<null, number>): void {
@@ -155,6 +157,7 @@ export const mulNode: ConfigNode = {
 
 export const divNode: ConfigNode = {
     id: "divNode",
+    alwaysUpdate: true,
     inputs: [numberIn, numberIn],
     outputs: [numberOut],
     exe: function (in1: EngineIO<null, number>, in2: EngineIO<null, number>, out: EngineIO<null, number>): void {

--- a/tests/core/predefined/EngineNodes.ts
+++ b/tests/core/predefined/EngineNodes.ts
@@ -4,7 +4,7 @@ import { addNode, constNode, divNode, forNode, ifNode, incrementTestValueNode, l
 export const rootEngineNode: EngineNode = {
     id: "root",
     configId: "rootNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: rootNode.inputs.map(io => { return { ...io } }),
     outputs: rootNode.outputs.map(io => { return { ...io } })
 }
@@ -12,7 +12,7 @@ export const rootEngineNode: EngineNode = {
 export const starterEngineNode: EngineNode = {
     id: "starterEngineNode",
     configId: "starterNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: starterNode.inputs.map(io => { return { ...io } }),
     outputs: starterNode.outputs.map(io => { return { ...io } })
 }
@@ -20,7 +20,7 @@ export const starterEngineNode: EngineNode = {
 export const incrementTestValueEngineNode: EngineNode = {
     id: "incrementTestValueEngineNode",
     configId: "incrementTestValueNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: incrementTestValueNode.inputs.map(io => { return { ...io } }),
     outputs: incrementTestValueNode.outputs.map(io => { return { ...io } })
 }
@@ -28,7 +28,7 @@ export const incrementTestValueEngineNode: EngineNode = {
 export const incrementTestValueEngineNode2: EngineNode = {
     id: "incrementTestValueEngineNode2",
     configId: "incrementTestValueNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: incrementTestValueNode.inputs.map(io => { return { ...io } }),
     outputs: incrementTestValueNode.outputs.map(io => { return { ...io } })
 }
@@ -36,7 +36,7 @@ export const incrementTestValueEngineNode2: EngineNode = {
 export const logEngineNode1: EngineNode = {
     id: "logEngineNode1",
     configId: "logNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: logNode.inputs.map(io => { return { ...io } }),
     outputs: logNode.outputs.map(io => { return { ...io } })
 }
@@ -44,7 +44,7 @@ export const logEngineNode1: EngineNode = {
 export const logEngineNode2: EngineNode = {
     id: "logEngineNode2",
     configId: "logNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: logNode.inputs.map(io => { return { ...io } }),
     outputs: logNode.outputs.map(io => { return { ...io } })
 }
@@ -52,7 +52,7 @@ export const logEngineNode2: EngineNode = {
 export const forEngineNode1: EngineNode = {
     id: "forEngineNode1",
     configId: "forNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: forNode.inputs.map(io => { return { ...io } }),
     outputs: forNode.outputs.map(io => { return { ...io } })
 }
@@ -60,7 +60,7 @@ export const forEngineNode1: EngineNode = {
 export const forEngineNodeTrigger: EngineNode = {
     id: "forEngineNodeTrigger",
     configId: "forNodeTrigger",
-    autoUpdate: true,
+    alwaysUpdate: true,
     inputs: forNode.inputs.map(io => { return { ...io } }),
     outputs: forNode.outputs.map(io => { return { ...io } })
 }
@@ -68,7 +68,7 @@ export const forEngineNodeTrigger: EngineNode = {
 export const ifEngineNode: EngineNode = {
     id: "ifEngineNode",
     configId: "ifNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: ifNode.inputs.map(io => { return { ...io } }),
     outputs: ifNode.outputs.map(io => { return { ...io } })
 }
@@ -76,7 +76,7 @@ export const ifEngineNode: EngineNode = {
 export const ifEngineNode2: EngineNode = {
     id: "ifEngineNode2",
     configId: "ifNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: ifNode.inputs.map(io => { return { ...io } }),
     outputs: ifNode.outputs.map(io => { return { ...io } })
 }
@@ -85,7 +85,7 @@ export const ifEngineNode2: EngineNode = {
 export const numberToStringConverterEngineNode1: EngineNode = {
     id: "numberToStringConverterEngineNode1",
     configId: "numberToStringConverterNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: numberToStringConverterNode.inputs.map(io => { return { ...io } }),
     outputs: numberToStringConverterNode.outputs.map(io => { return { ...io } })
 }
@@ -93,7 +93,7 @@ export const numberToStringConverterEngineNode1: EngineNode = {
 export const textHelloEngineNode: EngineNode = {
     id: "textHelloEngineNode",
     configId: "textNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: textNode.inputs.map(io => { return { ...io } }),
     outputs: textNode.outputs.map(io => { return { ...io } })
 }
@@ -101,7 +101,7 @@ export const textHelloEngineNode: EngineNode = {
 export const textWorldEngineNode: EngineNode = {
     id: "textWorldEngineNode",
     configId: "textNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: textNode.inputs.map(io => { return { ...io } }),
     outputs: textNode.outputs.map(io => { return { ...io } })
 }
@@ -109,7 +109,7 @@ export const textWorldEngineNode: EngineNode = {
 export const textCombineEngineNode1: EngineNode = {
     id: "textCombineEngineNode1",
     configId: "textCombineNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: textCombineNode.inputs.map(io => { return { ...io } }),
     outputs: textCombineNode.outputs.map(io => { return { ...io } })
 }
@@ -118,7 +118,7 @@ export const textCombineEngineNode1: EngineNode = {
 export const constZeroEngineNode: EngineNode = {
     id: "constZeroEngineNode",
     configId: "constNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: constNode.inputs.map(io => { return { ...io } }),
     outputs: constNode.outputs.map(io => { return { ...io } })
 }
@@ -126,7 +126,7 @@ export const constZeroEngineNode: EngineNode = {
 export const constOneEngineNode: EngineNode = {
     id: "constOneEngineNode",
     configId: "constNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: constNode.inputs.map(io => { return { ...io } }),
     outputs: constNode.outputs.map(io => { return { ...io } })
 }
@@ -134,7 +134,7 @@ export const constOneEngineNode: EngineNode = {
 export const constTwoEngineNode: EngineNode = {
     id: "constTwoEngineNode",
     configId: "constNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: constNode.inputs.map(io => { return { ...io } }),
     outputs: constNode.outputs.map(io => { return { ...io } })
 }
@@ -142,7 +142,7 @@ export const constTwoEngineNode: EngineNode = {
 export const constThreeEngineNode: EngineNode = {
     id: "constThreeEngineNode",
     configId: "constNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: constNode.inputs.map(io => { return { ...io } }),
     outputs: constNode.outputs.map(io => { return { ...io } })
 }
@@ -150,7 +150,7 @@ export const constThreeEngineNode: EngineNode = {
 export const constFourEngineNode: EngineNode = {
     id: "constFourEngineNode",
     configId: "constNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: constNode.inputs.map(io => { return { ...io } }),
     outputs: constNode.outputs.map(io => { return { ...io } })
 }
@@ -158,7 +158,7 @@ export const constFourEngineNode: EngineNode = {
 export const constFiveEngineNode: EngineNode = {
     id: "constFiveEngineNode",
     configId: "constNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: constNode.inputs.map(io => { return { ...io } }),
     outputs: constNode.outputs.map(io => { return { ...io } })
 }
@@ -166,7 +166,7 @@ export const constFiveEngineNode: EngineNode = {
 export const addEngineNode1: EngineNode = {
     id: "addEngineNode1",
     configId: "addNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: addNode.inputs.map(io => { return { ...io } }),
     outputs: addNode.outputs.map(io => { return { ...io } })
 }
@@ -174,7 +174,7 @@ export const addEngineNode1: EngineNode = {
 export const addEngineNode2: EngineNode = {
     id: "addEngineNode2",
     configId: "addNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: addNode.inputs.map(io => { return { ...io } }),
     outputs: addNode.outputs.map(io => { return { ...io } })
 }
@@ -182,7 +182,7 @@ export const addEngineNode2: EngineNode = {
 export const subEngineNode1: EngineNode = {
     id: "subEngineNode1",
     configId: "subNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: subNode.inputs.map(io => { return { ...io } }),
     outputs: subNode.outputs.map(io => { return { ...io } })
 }
@@ -190,7 +190,7 @@ export const subEngineNode1: EngineNode = {
 export const subEngineNode2: EngineNode = {
     id: "subEngineNode2",
     configId: "subNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: subNode.inputs.map(io => { return { ...io } }),
     outputs: subNode.outputs.map(io => { return { ...io } })
 }
@@ -198,7 +198,7 @@ export const subEngineNode2: EngineNode = {
 export const mulEngineNode1: EngineNode = {
     id: "mulEngineNode1",
     configId: "mulNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: mulNode.inputs.map(io => { return { ...io } }),
     outputs: mulNode.outputs.map(io => { return { ...io } })
 }
@@ -206,7 +206,7 @@ export const mulEngineNode1: EngineNode = {
 export const mulEngineNode2: EngineNode = {
     id: "mulEngineNode2",
     configId: "mulNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: mulNode.inputs.map(io => { return { ...io } }),
     outputs: mulNode.outputs.map(io => { return { ...io } })
 }
@@ -214,7 +214,7 @@ export const mulEngineNode2: EngineNode = {
 export const divEngineNode1: EngineNode = {
     id: "divEngineNode1",
     configId: "divNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: divNode.inputs.map(io => { return { ...io } }),
     outputs: divNode.outputs.map(io => { return { ...io } })
 }
@@ -222,7 +222,7 @@ export const divEngineNode1: EngineNode = {
 export const divEngineNode2: EngineNode = {
     id: "divEngineNode2",
     configId: "divNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: divNode.inputs.map(io => { return { ...io } }),
     outputs: divNode.outputs.map(io => { return { ...io } })
 }
@@ -230,7 +230,7 @@ export const divEngineNode2: EngineNode = {
 export const signalEngineNode1: EngineNode = {
     id: "signalEngineNode1",
     configId: "signalNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: signalNode.inputs.map(io => { return { ...io } }),
     outputs: signalNode.outputs.map(io => { return { ...io } })
 }
@@ -238,7 +238,7 @@ export const signalEngineNode1: EngineNode = {
 export const signalEngineNode2: EngineNode = {
     id: "signalEngineNode2",
     configId: "signalNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: signalNode.inputs.map(io => { return { ...io } }),
     outputs: signalNode.outputs.map(io => { return { ...io } })
 }
@@ -246,7 +246,7 @@ export const signalEngineNode2: EngineNode = {
 export const signalEngineNode3: EngineNode = {
     id: "signalEngineNode3",
     configId: "signalNode",
-    autoUpdate: false,
+    alwaysUpdate: false,
     inputs: signalNode.inputs.map(io => { return { ...io } }),
     outputs: signalNode.outputs.map(io => { return { ...io } })
 }


### PR DESCRIPTION
Implemented custom update option for nodes:
- NEVER: Nodes will only compute once upon initial dependency request.
- DYNAMIC: Nodes will compute when requested as a dependency and their dependencies (input values) have been changed
- ALWAYS: Nodes will always recompute when requested as a dependency 